### PR TITLE
fix: removed inkwell for web version

### DIFF
--- a/lib/link_text.dart
+++ b/lib/link_text.dart
@@ -6,7 +6,6 @@ library matrix_link_text;
 
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -310,26 +309,14 @@ TextSpan LinkTextSpans(
       }
       final uri = Uri.tryParse(link);
       if (valid && uri != null) {
-        if (kIsWeb) {
-          // on web recognizer in TextSpan does not work properly, so we use normal text w/ inkwell
-          textSpans.add(
-            WidgetSpan(
-              child: InkWell(
-                onTap: () => launchUrlIfHandler(uri),
-                child: Text(linkText, style: linkStyle),
-              ),
-            ),
-          );
-        } else {
-          textSpans.add(
-            LinkTextSpan(
-              text: linkText,
-              style: linkStyle,
-              url: uri,
-              onLinkTap: launchUrlIfHandler,
-            ),
-          );
-        }
+        textSpans.add(
+          LinkTextSpan(
+            text: linkText,
+            style: linkStyle,
+            url: uri,
+            onLinkTap: launchUrlIfHandler,
+          ),
+        );
       } else {
         textSpans.add(TextSpan(text: linkText, style: textStyle));
       }


### PR DESCRIPTION
Workaround Inkwell for textspan in web version doesn't seem to be necessary anymore
This must've been fixed by this PR https://github.com/flutter/engine/pull/23162 few months after adding the workaround in matrix_link_text.

It's working perfectly on my side after removing it, can you confirm if the bug you mentioned is gone ? 

https://github.com/Sorunome/matrix_link_text/assets/48354990/83b85ba8-6fc9-426c-8499-9078ec9aece9

